### PR TITLE
feat: support category and keyword banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ window.TS_BANNERS = {
 
 # Banner Attributes
 
-| Name            | Type   | Description                 |
-|-----------------|--------|-----------------------------|
-| topsort-api-key | String | Your Topsort API key        |
-| width           | Number | Banner width                |
-| height          | Number | Banner height               |
-| slot-id         | String | The slot ID for this banner |
+| Name            | Type            | Description                          |
+|-----------------|-----------------|--------------------------------------|
+| topsort-api-key | String          | Your Topsort API key                 |
+| width           | Number          | Banner width                         |
+| height          | Number          | Banner height                        |
+| slot-id         | String          | The slot ID for this banner          |
+| category-id     | Optional String | The category ID of the current page  |
+| search-query    | Optional String | The search query of the current page |
 
 
 # Banner Behaviors


### PR DESCRIPTION
Provide two new attributes to the banner web component:
- `category-id`: an optional ID for the category of the current PLP.
- `search-query`: an optional string containing the query sent by an user on the search results page.