### PR TITLE
feat: add optional location attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Directly from unpkg.com
 | slot-id      | String          | The slot ID for this banner          |
 | category-id  | Optional String | The category ID of the current page  |
 | search-query | Optional String | The search query of the current page |
+| location     | Optional String | The location for geotargeting        |
 
 # Banner Behaviors
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@topsort/banners",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A web component for displaying Topsort banner ads.",
   "type": "module",
   "author": "Topsort",

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,9 @@ interface Auction {
   category?: {
     id: string;
   };
+  geoTargeting?: {
+    location: string;
+  };
   searchQuery?: string;
 }
 
@@ -102,6 +105,9 @@ export class TopsortBanner extends LitElement {
 
   @property({ attribute: "search-query", type: String })
   readonly searchQuery?: string;
+
+  @property({ attribute: "location", type: String })
+  readonly location?: string;
 
   @state()
   private state: BannerState = {
@@ -149,6 +155,11 @@ export class TopsortBanner extends LitElement {
         };
       } else if (this.searchQuery) {
         auction.searchQuery = this.searchQuery;
+      }
+      if (this.location) {
+        auction.geoTargeting = {
+          location: this.location,
+        };
       }
       const token = window.TS.token;
       const url = window.TS.url || "https://api.topsort.com";


### PR DESCRIPTION
Adds location as an optional attribute to enable geo targeting for banners through this library. Bumps the version to 0.1.1.