### PR TITLE
fix: initialize pnpm in release action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
         # No major tag unfortunately
         # https://github.com/crate-ci/typos/issues/857
-      - uses: crate-ci/typos@v1.20.10
+      - uses: crate-ci/typos@v1.22.3
 
   tsc:
     name: Type checks
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install PNPM
         id: pnpm-install
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        name: Install PNPM
+        id: pnpm-install
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
This was missing from the `pnpm` migration. Also, update a few actions to their latest counterpart.