### PR TITLE
Change event : add callerId

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The various states are `loading`, `ready`, `error`, and `nowinners`.
 
 ```javascript
 document.querySelector('#my-slot-id').addEventListener('statechange', (event) => {
-  console.log(event.detail); // { status: 'ready', banner: { ... } }
+  console.log(event.detail); // { slotId: slotid, caller: id, state: {status: 'ready', banner: { ... }} }
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ Directly from unpkg.com
 <script
   async
   type="module"
-  src="https://unpkg.com/@topsort/banners@0.2.0/dist/banners.mjs"
+  src="https://unpkg.com/@topsort/banners@0.3.0/dist/banners.mjs"
 ></script>
 <script async type="module" src="https://unpkg.com/@topsort/analytics.js"></script>
+<body>
+  <topsort-banner width="600" height="400" id="<your html element id>" slot-id="<your slot id>"></topsort-banner>
+</body>
 <script>
   // Set API key for auctions and events
   window.TS = {
@@ -40,10 +43,11 @@ Directly from unpkg.com
       return el;
     },
   };
+
+  document.querySelector('<your html element id>').addEventListener('statechange', (event) => {
+    console.log(event.detail.caller);
+  });
 </script>
-<body>
-  <topsort-banner width="600" height="400" slot-id="<your slot id>"></topsort-banner>
-</body>
 ```
 
 # Banner Attributes
@@ -52,7 +56,8 @@ Directly from unpkg.com
 | ------------ | --------------- | ------------------------------------ |
 | width        | Number          | Banner width                         |
 | height       | Number          | Banner height                        |
-| id           | String          | The slot ID for this banner          |
+| id           | String          | The html element ID for this banner          |
+| slot-id           | String          | The slot ID for this banner          |
 | category-id  | Optional String | The category ID of the current page  |
 | search-query | Optional String | The search query of the current page |
 | location     | Optional String | The location for geotargeting        |

--- a/index.html
+++ b/index.html
@@ -11,6 +11,21 @@
     <script async type="module" src="https://unpkg.com/@topsort/analytics.js"></script>
     <script async type="module" src="src/index.ts"></script>
   </head>
+  
+  <style>
+    body {
+      justify-content: center;
+      padding: 20px;
+    }
+  </style>
+  <body>
+    <div>
+      <topsort-banner id="first-banner" slot-id="fr_728x90" width="728" height="90"></topsort-banner>
+    </div>
+    <div>
+      <topsort-banner id="second-banner" slot-id="fr_728x90" width="728" height="90"></topsort-banner>
+    </div>
+  </body>
   <script>
     // Set up authentication for auctions and events
     window.TS = {
@@ -32,17 +47,13 @@
         return div;
       },
     };
+
+    document.querySelector('#first-banner').addEventListener('statechange', (event) => {
+      console.log(event.detail.caller);
+    });
+
+    document.querySelector('#second-banner').addEventListener('statechange', (event) => {  
+      console.log(event.detail.caller);
+    });
   </script>
-  <style>
-    body {
-      display: flex;
-      justify-content: center;
-      padding: 20px;
-    }
-  </style>
-  <body>
-    <div style="outline 1px solid black">
-      <topsort-banner id="<your-slot-id>" width="600" height="400"></topsort-banner>
-    </div>
-  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -49,11 +49,11 @@
     };
 
     document.querySelector('#first-banner').addEventListener('statechange', (event) => {
-      console.log(event.detail.caller);
+      console.log(event.detail);
     });
 
     document.querySelector('#second-banner').addEventListener('statechange', (event) => {  
-      console.log(event.detail.caller);
+      console.log(event.detail);
     });
   </script>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@topsort/banners",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A web component for displaying Topsort banner ads.",
   "type": "module",
   "author": "Topsort",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A web component for displaying Topsort banner ads.",
   "type": "module",
   "author": "Topsort",
-  "packageManager": "pnpm@9.0.6",
+  "packageManager": "pnpm@9.1.4",
   "engines": {
     "node": ">=20.0.0",
     "pnpm": ">=9"

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,9 @@ export class TopsortBanner extends LitElement {
   readonly height = 0;
 
   @property({ attribute: "id", type: String })
+  readonly callerId: string = "";
+
+  @property({ attribute: "slot-id", type: String })
   readonly slotId: string = "";
 
   @property({ attribute: "category-id", type: String })
@@ -178,7 +181,7 @@ export class TopsortBanner extends LitElement {
   private setState(state: BannerState) {
     this.state = state;
     const event = new CustomEvent("statechange", {
-      detail: { state, slotId: this.slotId },
+      detail: { state, caller: this.callerId },
       bubbles: true,
       composed: true,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ export class TopsortBanner extends LitElement {
   private setState(state: BannerState) {
     this.state = state;
     const event = new CustomEvent("statechange", {
-      detail: { state, caller: this.callerId },
+      detail: { state, slotId: this.slotId, callerId: this.callerId },
       bubbles: true,
       composed: true,
     });


### PR DESCRIPTION
ersion 0.2.0 uses an id attribute which also acts as the slot-id for event emitting.

We have pages where it would be possible to have twice the same banner type (same slot-id).
This would cause issues seeing we wouldn't have a unique identifier for our banners anymore.
This would generate invalid html, i.e. jQuery would have issues with this).

This is why I reintroduced the slot-id which acts as the slot id from version 0.1.1 and lower.
Next to that I kept the id field which acts as the caller-id. In the emitted event this caller id is returned together with the slotId.

Please feel free to reject if this is not what you have in mind for the package.
(we can work around the issues but the seems a bit cleaner to us.)