### PR TITLE
docs(readme): update slot-id to id in the banner component

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Directly from unpkg.com
   };
 </script>
 <body>
-  <topsort-banner width="600" height="400" slot-id="<your slot id>"></topsort-banner>
+  <topsort-banner width="600" height="400" id="<your slot id>"></topsort-banner>
 </body>
 ```
 


### PR DESCRIPTION
 This readme version still has slot-id instead of id as property name for the banner HTML component.