### PR TITLE
fix: task is constantly retrying

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,8 @@
     // Setup @topsort/banners.js
     window.TS_BANNERS = {
       getLoadingElement() {
-        return document.createElement("nb-skeleton");
+        const div = document.createElement("div");
+        div.innerText = "Loading Banner...";
       },
       getErrorElement(error) {
         const div = document.createElement("div");

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,3 @@
-export interface NoWinners {
-  status: "nowinners";
-}
-
-export interface Ready {
-  status: "ready";
-  banners: Banner[];
-}
-
 export interface Auction {
   type: "banners";
   slots: 1;
@@ -30,5 +21,3 @@ export interface Banner {
   resolvedBidId: string;
   asset: [{ url: string }];
 }
-
-export type BannerState = NoWinners | Ready;


### PR DESCRIPTION
The `Task` constructor uses regular comparison in the `args` function to know if the task should be re-fired. Because we were constructing an object in each call, even if it contained the same data, its hash meant the objects were different.