### PR TITLE
feat: banner-context

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_TS_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .DS_Store
 dist/
 types/
+.env

--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ Directly from unpkg.com
 </body>
 ```
 
+## Rendering multiple banners with one slot ID
+
+You can render multiple banners using the same slot ID and dimensions by setting up
+a banner context. This is useful when you want to run an auction with multiple results.
+To do that you have to use the `topsort-banner-context` and `topsort-banner-slot` elements.
+`topsort-banner-context` takes the same properties as the regular `topsort-banner` element.
+
+```html
+<topsort-banner-context width="600" height="400" id="<your slot id>">
+  <topsort-banner-slot rank="1"></topsort-banner-slot>
+  <topsort-banner-slot rank="2"></topsort-banner-slot>
+  <topsort-banner-slot rank="3"></topsort-banner-slot>
+</topsort-banner-context>
+```
+
 # Banner Attributes
 
 | Name                   | Type             | Description                                                                 |

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ Directly from unpkg.com
 
 You can render multiple banners using the same slot ID and dimensions by setting up
 a banner context. This is useful when you want to run an auction with multiple results.
-To do that you have to use the `topsort-banner-context` and `topsort-banner-slot` elements.
-`topsort-banner-context` takes the same properties as the regular `topsort-banner` element.
+To do that you have to pass the attribute `context="true"` to the `topsort-banner` and
+use `topsort-banner-slot` as children elements.
 
 ```html
-<topsort-banner-context width="600" height="400" id="<your slot id>">
+<topsort-banner context="true" width="600" height="400" id="<your slot id>">
   <topsort-banner-slot rank="1"></topsort-banner-slot>
   <topsort-banner-slot rank="2"></topsort-banner-slot>
   <topsort-banner-slot rank="3"></topsort-banner-slot>
@@ -73,10 +73,16 @@ To do that you have to use the `topsort-banner-context` and `topsort-banner-slot
 | category-disjunctions* | Optional String  | Comma (,) separated list of category IDs, the item must match any           |
 | search-query           | Optional String  | The search query of the current page                                        |
 | location               | Optional String  | The location for geotargeting                                               |
-| new-tab                | Optional Boolean | Opens the banner's link in a new tab (defaults to false)                             |
+| new-tab                | Optional Boolean | Opens the banner's link in a new tab (defaults to false)                    |
+| context                | Optional Boolean | Uses the element as a context provider to render multiple banners           |
 
 \* Only one of `[category-id, category-ids, category-disjunctions]` must be set.
 If multiple are set, only the first will be considered, in that order.
+
+# Banner Slot Attributes
+| Name | Type   | Description                                                                                                           |
+|------|--------|-----------------------------------------------------------------------------------------------------------------------|
+| rank | Number | The ranking of the slot. Ranks should be sorted the same as the winning bids. The lower the rank, the higher the bid  |
 
 # Banner Behaviors
 

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
               &lt;h3&gt;Second Banner&lt;/h3&gt;
               &lt;topsort-banner-slot rank="2"&gt;&lt;/topsort-banner-slot&gt;
             &lt;/div&gt;
-          &lt;/topsort-banner-context&gt;
+          &lt;/topsort-banner&gt;
         </code>
       </pre>
       <topsort-banner id="an-example-slot" width="800" height="400" context="true">

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
       type="module"
       src="node_modules/skeleton-webcomponent-loader/dist/skeleton-webcomponent/skeleton-webcomponent.esm.js"
     ></script>
+    <script async type="module" src="https://unpkg.com/@topsort/analytics.js"></script>
     <script async type="module" src="src/index.ts"></script>
   </head>
   <script>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,8 @@
     // Setup @topsort/banners.js
     window.TS_BANNERS = {
       getLoadingElement() {
-        return document.createElement("nb-skeleton");
+        const div = document.createElement("div");
+        div.innerText = "Loading Banner...";
       },
       getErrorElement(error) {
         const div = document.createElement("div");

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
       <h3>Multiple Banners under one context</h3>
       <pre>
         <code>
-          &lt;topsort-banner-context id="an-example-slot" width="800" height="400" context&gt;
+          &lt;topsort-banner id="an-example-slot" width="800" height="400" context&gt;
             &lt;div&gt;
               &lt;h3&gt;First Banner&lt;/h3&gt;
               &lt;pre&gt;
@@ -77,7 +77,7 @@
           &lt;/topsort-banner-context&gt;
         </code>
       </pre>
-      <topsort-banner-context id="an-example-slot" width="800" height="400" context>
+      <topsort-banner id="an-example-slot" width="800" height="400" context="true">
         <div>
           <h3>First Banner</h3>
           <topsort-banner-slot rank="1"></topsort-banner-slot>
@@ -86,7 +86,7 @@
           <h3>Second Banner</h3>
           <topsort-banner-slot rank="2"></topsort-banner-slot>
         </div>
-      </topsort-banner-context>
+      </topsort-banner>
     </div>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,13 +8,12 @@
       type="module"
       src="node_modules/skeleton-webcomponent-loader/dist/skeleton-webcomponent/skeleton-webcomponent.esm.js"
     ></script>
-    <script async type="module" src="https://unpkg.com/@topsort/analytics.js"></script>
     <script async type="module" src="src/index.ts"></script>
   </head>
   <script>
     // Set up authentication for auctions and events
     window.TS = {
-      token: "<your-topsort-token>",
+      token: "%VITE_TS_TOKEN%",
     };
 
     // Setup @topsort/banners.js
@@ -25,11 +24,14 @@
       },
       getErrorElement(error) {
         const div = document.createElement("div");
+        const pre = document.createElement("pre");
         if (error.name === "TopsortConfigurationError") {
-          div.innerText = error.message;
+          pre.innerText = error.message;
         } else {
-          div.innerText = "Couldn't load Banner. Check console for more details.";
+          pre.innerText = "Couldn't load Banner. Check console for more details.";
+          pre.innerText = `${error.name}: ${error.message}`;
         }
+        div.appendChild(pre);
         return div;
       },
     };
@@ -42,8 +44,48 @@
     }
   </style>
   <body>
+    <div style="padding-right: 1rem">
+      <h3>Standalone Banner</h3>
+      <pre>
+        <code>
+          &lt;topsort-banner id="an-example-slot" width="800" height="400"&gt;&lt;/topsort-banner&gt;
+        </code>
+      </pre>
+      <div style="outline 1px solid black">
+        <topsort-banner id="an-example-slot" width="800" height="400"></topsort-banner>
+      </div>
+    </div>
     <div style="outline 1px solid black">
-      <topsort-banner id="<your-slot-id>" width="600" height="400"></topsort-banner>
+      <h3>Multiple Banners under one context</h3>
+      <pre>
+        <code>
+          &lt;topsort-banner-context id="an-example-slot" width="800" height="400" context&gt;
+            &lt;div&gt;
+              &lt;h3&gt;First Banner&lt;/h3&gt;
+              &lt;pre&gt;
+                &lt;code&gt;
+                  &lt;topsort-banner-slot rank="1"&gt;&lt;/topsort-banner-slot&gt;
+                &lt;/code&gt;
+              &lt;/pre&gt;
+              &lt;topsort-banner-slot rank="1"&gt;&lt;/topsort-banner-slot&gt;
+            &lt;/div&gt;
+            &lt;div&gt;
+              &lt;h3&gt;Second Banner&lt;/h3&gt;
+              &lt;topsort-banner-slot rank="2"&gt;&lt;/topsort-banner-slot&gt;
+            &lt;/div&gt;
+          &lt;/topsort-banner-context&gt;
+        </code>
+      </pre>
+      <topsort-banner-context id="an-example-slot" width="800" height="400" context>
+        <div>
+          <h3>First Banner</h3>
+          <topsort-banner-slot rank="1"></topsort-banner-slot>
+        </div>
+        <div>
+          <h3>Second Banner</h3>
+          <topsort-banner-slot rank="2"></topsort-banner-slot>
+        </div>
+      </topsort-banner-context>
     </div>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "vite-plugin-dts": "^3.8.3"
   },
   "dependencies": {
+    "@lit/context": "^1.1.2",
     "@lit/task": "^1.0.1",
     "lit": "^3.1.3",
     "skeleton-webcomponent-loader": "^2.1.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@lit/context':
+        specifier: ^1.1.2
+        version: 1.1.2
       '@lit/task':
         specifier: ^1.0.1
         version: 1.0.1
@@ -249,6 +252,9 @@ packages:
 
   '@lit-labs/ssr-dom-shim@1.2.0':
     resolution: {integrity: sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g==}
+
+  '@lit/context@1.1.2':
+    resolution: {integrity: sha512-S0nw2C6Tkm7fVX5TGYqeROGD+Z9Coa2iFpW+ysYBDH3YvCqOY3wVQvSgwbaliLJkjTnSEYCBe9qFqKV8WUFpVw==}
 
   '@lit/reactive-element@2.0.4':
     resolution: {integrity: sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==}
@@ -850,6 +856,10 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.4.15': {}
 
   '@lit-labs/ssr-dom-shim@1.2.0': {}
+
+  '@lit/context@1.1.2':
+    dependencies:
+      '@lit/reactive-element': 2.0.4
 
   '@lit/reactive-element@2.0.4':
     dependencies:

--- a/src/auction.ts
+++ b/src/auction.ts
@@ -26,11 +26,9 @@ export async function runAuction(
   auction: Auction,
   { signal, logError }: AuctionOptions,
 ): Promise<Banner[]> {
-  console.debug("Running auction", auction);
   const device = getDeviceType();
   const token = window.TS.token;
   const url = window.TS.url || "https://api.topsort.com";
-  console.debug(JSON.stringify({ auctions: [auction] }, null, 2));
   const res = await fetch(new URL(`${url}/v2/auctions`), {
     method: "POST",
     mode: "cors",
@@ -50,7 +48,6 @@ export async function runAuction(
     throw new Error(error.message);
   }
   const data = await res.json();
-  console.debug(data);
   const result = data.results[0];
   if (!result) throw new TopsortRequestError("No auction results", res.status);
   if (result.error) {

--- a/src/auction.ts
+++ b/src/auction.ts
@@ -1,0 +1,61 @@
+import { TopsortRequestError } from "./errors";
+import type { Auction, Banner } from "./types";
+
+export const getDeviceType = (): "mobile" | "desktop" => {
+  const ua = navigator.userAgent;
+  if (/(tablet|ipad|playbook|silk)|(android(?!.*mobi))/i.test(ua)) {
+    //return "tablet";
+    return "mobile";
+  }
+  if (
+    /Mobile|iP(hone|od)|Android|BlackBerry|IEMobile|Kindle|Silk-Accelerated|(hpw|web)OS|Opera M(obi|ini)/.test(
+      ua,
+    )
+  ) {
+    return "mobile";
+  }
+  return "desktop";
+};
+
+interface AuctionOptions {
+  signal: AbortSignal;
+  logError: (error: unknown) => void;
+}
+
+export async function runAuction(
+  auction: Auction,
+  { signal, logError }: AuctionOptions,
+): Promise<Banner[]> {
+  console.debug("Running auction", auction);
+  const device = getDeviceType();
+  const token = window.TS.token;
+  const url = window.TS.url || "https://api.topsort.com";
+  console.debug(JSON.stringify({ auctions: [auction] }, null, 2));
+  const res = await fetch(new URL(`${url}/v2/auctions`), {
+    method: "POST",
+    mode: "cors",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "X-UA": `topsort/banners-${import.meta.env.PACKAGE_VERSION} (${device}})`,
+    },
+    body: JSON.stringify({
+      auctions: [auction],
+    }),
+    signal,
+  });
+  if (!res.ok) {
+    const error = await res.json();
+    logError(error);
+    throw new Error(error.message);
+  }
+  const data = await res.json();
+  console.debug(data);
+  const result = data.results[0];
+  if (!result) throw new TopsortRequestError("No auction results", res.status);
+  if (result.error) {
+    logError(result.error);
+    throw new Error(result.error);
+  }
+  return result.winners;
+}

--- a/src/auction.ts
+++ b/src/auction.ts
@@ -35,7 +35,7 @@ export async function runAuction(
     headers: {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
-      "X-UA": `topsort/banners-${import.meta.env.PACKAGE_VERSION} (${device}})`,
+      "X-UA": `topsort/banners-${import.meta.env.PACKAGE_VERSION} (${device})`,
     },
     body: JSON.stringify({
       auctions: [auction],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,11 @@
+import { ContextProvider, consume, createContext, provide } from "@lit/context";
 import { Task } from "@lit/task";
 import { LitElement, type TemplateResult, css, html } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { TopsortConfigurationError, TopsortRequestError } from "./errors";
-import type { Auction, Banner } from "./types";
+import { customElement, property, state } from "lit/decorators.js";
+import { runAuction } from "./auction";
+import { TopsortConfigurationError } from "./errors";
+import { BannerComponent } from "./mixin";
+import type { Auction, Banner, BannerContext } from "./types";
 
 /* Set up global environment for TS_BANNERS */
 
@@ -30,107 +33,59 @@ function logError(error: unknown) {
   }
 }
 
-const getDeviceType = (): "mobile" | "desktop" => {
-  const ua = navigator.userAgent;
-  if (/(tablet|ipad|playbook|silk)|(android(?!.*mobi))/i.test(ua)) {
-    //return "tablet";
-    return "mobile";
+// The following methods are used to customize the appearance of the banner component.
+function getLink(banner: Banner): string {
+  if (window.TS_BANNERS.getLink) {
+    return window.TS_BANNERS.getLink(banner);
   }
-  if (
-    /Mobile|iP(hone|od)|Android|BlackBerry|IEMobile|Kindle|Silk-Accelerated|(hpw|web)OS|Opera M(obi|ini)/.test(
-      ua,
-    )
-  ) {
-    return "mobile";
+  if (banner.type === "url") {
+    return banner.id;
   }
-  return "desktop";
-};
+  return `${banner.type}/${banner.id}`;
+}
 
-/**
- * A banner web component that runs an auction and renders the winning banner.
- */
-@customElement("topsort-banner")
-export class TopsortBanner extends LitElement {
-  @property({ type: Number })
-  readonly width = 0;
-
-  @property({ type: Number })
-  readonly height = 0;
-
-  @property({ attribute: "id", type: String })
-  readonly slotId: string = "";
-
-  @property({ attribute: "category-id", type: String })
-  readonly categoryId?: string;
-
-  @property({ attribute: "category-ids", type: String })
-  readonly categoryIds?: string;
-
-  @property({ attribute: "category-disjunctions", type: String })
-  readonly categoryDisjunctions?: string;
-
-  @property({ attribute: "search-query", type: String })
-  readonly searchQuery?: string;
-
-  @property({ attribute: "location", type: String })
-  readonly location?: string;
-
-  private task = new Task(this, {
-    task: (...args) => this.runAuction(...args),
-    args: () => [],
-  });
-
-  private getLink(banner: Banner): string {
-    if (window.TS_BANNERS.getLink) {
-      return window.TS_BANNERS.getLink(banner);
-    }
-    if (banner.type === "url") {
-      return banner.id;
-    }
-    return `${banner.type}/${banner.id}`;
+function getLoadingElement(): TemplateResult {
+  if (window.TS_BANNERS.getLoadingElement) {
+    const element = window.TS_BANNERS.getLoadingElement();
+    return html`${element}`;
   }
+  // By default, hide the component while loading
+  return html``;
+}
 
-  private getLoadingElement(): TemplateResult {
-    if (window.TS_BANNERS.getLoadingElement) {
-      const element = window.TS_BANNERS.getLoadingElement();
-      return html`${element}`;
-    }
-    // By default, hide the component while loading
-    return html``;
+function getErrorElement(error: unknown): TemplateResult {
+  if (window.TS_BANNERS.getErrorElement) {
+    const element = window.TS_BANNERS.getErrorElement(error);
+    return html`${element}`;
   }
+  // By default, hide the component if there is an error
+  return html``;
+}
 
-  private getErrorElement(error: unknown): TemplateResult {
-    if (window.TS_BANNERS.getErrorElement) {
-      const element = window.TS_BANNERS.getErrorElement(error);
-      return html`${element}`;
-    }
-    // By default, hide the component if there is an error
-    return html``;
+function getNoWinnersElement(): TemplateResult {
+  if (window.TS_BANNERS.getNoWinnersElement) {
+    const element = window.TS_BANNERS.getNoWinnersElement();
+    return html`${element}`;
   }
+  // By default, hide the component if there are no winners
+  return html``;
+}
 
-  private getNoWinnersElement(): TemplateResult {
-    if (window.TS_BANNERS.getNoWinnersElement) {
-      const element = window.TS_BANNERS.getNoWinnersElement();
-      return html`${element}`;
-    }
-    // By default, hide the component if there are no winners
-    return html``;
+function getBannerElement(banner: Banner, width: number, height: number): TemplateResult {
+  if (window.TS_BANNERS.getBannerElement) {
+    const element = window.TS_BANNERS.getBannerElement(banner);
+    return html`${element}`;
   }
-
-  private getBannerElement(banner: Banner): TemplateResult {
-    if (window.TS_BANNERS.getBannerElement) {
-      const element = window.TS_BANNERS.getBannerElement(banner);
-      return html`${element}`;
-    }
-    const src = banner.asset[0].url;
-    const style = css`
+  console.debug(banner);
+  const src = banner.asset[0].url;
+  const style = css`
       img {
-        width: ${this.width}px;
-        height: ${this.height}px;
+        width: ${width}px;
+        height: ${height}px;
       }
     `;
-    const href = this.getLink(banner);
-    return html`
+  const href = getLink(banner);
+  return html`
         <div style="${style}"
              data-ts-clickable
              data-ts-resolved-bid=${banner.resolvedBidId}
@@ -140,97 +95,140 @@ export class TopsortBanner extends LitElement {
           </a>
         </div>
         `;
-  }
+}
 
-  private emitEvent(status: string) {
-    const event = new CustomEvent("statechange", {
-      detail: { slotId: this.slotId, status },
-      bubbles: true,
-      composed: true,
-    });
-    this.dispatchEvent(event);
-  }
+/**
+ * A banner web component that runs an auction and renders the winning banner.
+ */
+@customElement("topsort-banner")
+export class TopsortBanner extends BannerComponent(LitElement) {
+  private task = new Task(this, {
+    task: (_, options) => runAuction(this.buildAuction(), { ...options, logError }),
+    args: () => [],
+  });
 
-  private buildAuction(): Auction {
-    const device = getDeviceType();
-    const auction: Auction = {
-      type: "banners",
-      slots: 1,
-      device,
-      slotId: this.slotId,
-    };
-    if (this.categoryId) {
-      auction.category = {
-        id: this.categoryId,
-      };
-    } else if (this.categoryIds) {
-      auction.category = {
-        ids: this.categoryIds.split(",").map((item) => item.trim()),
-      };
-    } else if (this.categoryDisjunctions) {
-      auction.category = {
-        disjunctions: [this.categoryDisjunctions.split(",").map((item) => item.trim())],
-      };
-    } else if (this.searchQuery) {
-      auction.searchQuery = this.searchQuery;
+  protected render() {
+    if (!window.TS.token || !this.slotId) {
+      return getErrorElement(new TopsortConfigurationError(window.TS.token, this.slotId));
     }
-    if (this.location) {
-      auction.geoTargeting = {
-        location: this.location,
-      };
+    return this.task.render({
+      pending: () => getLoadingElement(),
+      complete: (banners) => {
+        this.emitEvent(banners.length ? "ready" : "nowinners");
+        if (!banners.length) {
+          return getNoWinnersElement();
+        }
+        return getBannerElement(banners[0], this.height, this.width);
+      },
+      error: (error) => getErrorElement(error),
+    });
+  }
+
+  // avoid shadow dom since we cannot attach to events via analytics.js
+  protected createRenderRoot() {
+    return this;
+  }
+}
+
+const bannerContext = createContext<BannerContext>(Symbol("banner-context"));
+const bannerContextHasChanged = (newVal: BannerContext, oldVal?: BannerContext) => {
+  if (!oldVal && newVal) {
+    return true;
+  }
+  if (!newVal || !oldVal) {
+    return false;
+  }
+  return (
+    newVal.width !== oldVal.width ||
+    newVal.height !== oldVal.height ||
+    newVal.banners !== oldVal.banners ||
+    newVal.error !== oldVal.error
+  );
+};
+
+@customElement("topsort-banner-context")
+export class TopsortBannerContext extends BannerComponent(LitElement) {
+  @provide({ context: bannerContext })
+  @property({
+    state: true,
+    attribute: false,
+    hasChanged: bannerContextHasChanged,
+  })
+  protected context: BannerContext = {
+    width: this.width,
+    height: this.height,
+  };
+
+  // task = new Task(this, {
+  //   task: async (_, options) => await runAuction(this.buildAuction(), { ...options, logError }),
+  //   args: () => [],
+  // });
+
+  buildAuction(): Auction {
+    const auction = super.buildAuction();
+    const slots = this.querySelectorAll("topsort-banner-slot").length;
+    if (slots > 1) {
+      auction.slots = slots;
     }
     return auction;
   }
 
-  private async runAuction(_: never[], { signal }: { signal: AbortSignal }): Promise<Banner[]> {
-    const auction = this.buildAuction();
-    console.debug("Running auction", auction);
-    const device = getDeviceType();
-    const token = window.TS.token;
-    const url = window.TS.url || "https://api.topsort.com";
-    const res = await fetch(new URL(`${url}/v2/auctions`), {
-      method: "POST",
-      mode: "cors",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-        "X-UA": `topsort/banners-${import.meta.env.PACKAGE_VERSION} (${device}})`,
-      },
-      body: JSON.stringify({
-        auctions: [auction],
-      }),
-      signal,
-    });
-    if (!res.ok) {
-      const error = await res.json();
-      logError(error);
-      throw new Error(error.message);
-    }
-    const data = await res.json();
-    const result = data.results[0];
-    if (!result) throw new TopsortRequestError("No auction results", res.status);
-    if (result.error) {
-      logError(result.error);
-      throw new Error(result.error);
-    }
-    return result.winners;
+  protected render() {
+    return html`<slot></slot>`;
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    const signal = new AbortController().signal;
+    this.context = {
+      width: this.width,
+      height: this.height,
+    };
+    runAuction(this.buildAuction(), {
+      logError,
+      signal,
+    })
+      .then((banners) => {
+        console.log("banners", banners);
+        this.context = {
+          width: this.width,
+          height: this.height,
+          banners,
+        };
+      })
+      .catch((error) => {
+        console.error(error);
+        this.context = {
+          width: this.width,
+          height: this.height,
+          error,
+        };
+      });
+  }
+}
+
+@customElement("topsort-banner-slot")
+export class TopsortBannerSlot extends LitElement {
+  @consume({ context: bannerContext })
+  @property({ attribute: false })
+  public context?: BannerContext;
+
+  @property({ attribute: "rank", type: Number })
+  readonly rank = 0;
+
   protected render() {
-    if (!window.TS.token || !this.slotId) {
-      return this.getErrorElement(new TopsortConfigurationError(window.TS.token, this.slotId));
+    console.log("render", this, this.context);
+    if (this.context?.error) {
+      return getErrorElement(this.context.error);
     }
-    return this.task.render({
-      pending: () => this.getLoadingElement(),
-      complete: (banners) => {
-        this.emitEvent(banners.length ? "ready" : "nowinners");
-        if (!banners.length) {
-          return this.getNoWinnersElement();
-        }
-        return this.getBannerElement(banners[0]);
-      },
-      error: (error) => this.getErrorElement(error),
-    });
+    if (!this.context?.banners) {
+      return html``;
+    }
+    const banner = this.context.banners[this.rank - 1];
+    if (!banner) {
+      return html``;
+    }
+    return getBannerElement(banner, this.context.width, this.context.height);
   }
 
   // avoid shadow dom since we cannot attach to events via analytics.js

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ export class TopsortBannerContext extends BannerComponent(LitElement) {
   protected context: BannerContext = {
     width: this.width,
     height: this.height,
-		newTab: this.newTab,
+    newTab: this.newTab,
   };
 
   buildAuction(): Auction {

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,12 @@ function getNoWinnersElement(): TemplateResult {
   return html``;
 }
 
-function getBannerElement(banner: Banner, width: number, height: number): TemplateResult {
+function getBannerElement(
+  banner: Banner,
+  width: number,
+  height: number,
+  newTab: boolean,
+): TemplateResult {
   if (window.TS_BANNERS.getBannerElement) {
     const element = window.TS_BANNERS.getBannerElement(banner);
     return html`${element}`;
@@ -85,10 +90,10 @@ function getBannerElement(banner: Banner, width: number, height: number): Templa
       }
     `;
   const href = getLink(banner);
-    const imgtag = html`<img src="${src}" alt="Topsort banner"></img>`;
-    const atag = this.newTab
-      ? html`<a href="${href}" target="_blank">${imgtag}</a>`
-      : html`<a href="${href}">${imgtag}</a>`;
+  const imgtag = html`<img src="${src}" alt="Topsort banner"></img>`;
+  const atag = newTab
+    ? html`<a href="${href}" target="_blank">${imgtag}</a>`
+    : html`<a href="${href}">${imgtag}</a>`;
   return html`
         <div style="${style}"
              data-ts-clickable
@@ -120,7 +125,7 @@ export class TopsortBanner extends BannerComponent(LitElement) {
         if (!banners.length) {
           return getNoWinnersElement();
         }
-        return getBannerElement(banners[0], this.height, this.width);
+        return getBannerElement(banners[0], this.height, this.width, this.newTab);
       },
       error: (error) => getErrorElement(error),
     });
@@ -159,6 +164,7 @@ export class TopsortBannerContext extends BannerComponent(LitElement) {
   protected context: BannerContext = {
     width: this.width,
     height: this.height,
+		newTab: this.newTab,
   };
 
   buildAuction(): Auction {
@@ -180,6 +186,7 @@ export class TopsortBannerContext extends BannerComponent(LitElement) {
     this.context = {
       width: this.width,
       height: this.height,
+      newTab: this.newTab,
     };
     runAuction(this.buildAuction(), {
       logError,
@@ -189,6 +196,7 @@ export class TopsortBannerContext extends BannerComponent(LitElement) {
         this.context = {
           width: this.width,
           height: this.height,
+          newTab: this.newTab,
           banners,
         };
       })
@@ -197,6 +205,7 @@ export class TopsortBannerContext extends BannerComponent(LitElement) {
         this.context = {
           width: this.width,
           height: this.height,
+          newTab: this.newTab,
           error,
         };
       });
@@ -223,7 +232,7 @@ export class TopsortBannerSlot extends LitElement {
     if (!banner) {
       return html``;
     }
-    return getBannerElement(banner, this.context.width, this.context.height);
+    return getBannerElement(banner, this.context.width, this.context.height, this.context.newTab);
   }
 
   // avoid shadow dom since we cannot attach to events via analytics.js

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import { ContextProvider, consume, createContext, provide } from "@lit/context";
+import { consume, createContext, provide } from "@lit/context";
 import { Task } from "@lit/task";
 import { LitElement, type TemplateResult, css, html } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { customElement, property } from "lit/decorators.js";
 import { runAuction } from "./auction";
 import { TopsortConfigurationError } from "./errors";
 import { BannerComponent } from "./mixin";
@@ -159,11 +159,6 @@ export class TopsortBannerContext extends BannerComponent(LitElement) {
     height: this.height,
   };
 
-  // task = new Task(this, {
-  //   task: async (_, options) => await runAuction(this.buildAuction(), { ...options, logError }),
-  //   args: () => [],
-  // });
-
   buildAuction(): Auction {
     const auction = super.buildAuction();
     const slots = this.querySelectorAll("topsort-banner-slot").length;
@@ -189,7 +184,6 @@ export class TopsortBannerContext extends BannerComponent(LitElement) {
       signal,
     })
       .then((banners) => {
-        console.log("banners", banners);
         this.context = {
           width: this.width,
           height: this.height,
@@ -197,7 +191,7 @@ export class TopsortBannerContext extends BannerComponent(LitElement) {
         };
       })
       .catch((error) => {
-        console.error(error);
+        logError(error);
         this.context = {
           width: this.width,
           height: this.height,
@@ -209,7 +203,7 @@ export class TopsortBannerContext extends BannerComponent(LitElement) {
 
 @customElement("topsort-banner-slot")
 export class TopsortBannerSlot extends LitElement {
-  @consume({ context: bannerContext })
+  @consume({ context: bannerContext, subscribe: true })
   @property({ attribute: false })
   public context?: BannerContext;
 
@@ -217,7 +211,6 @@ export class TopsortBannerSlot extends LitElement {
   readonly rank = 0;
 
   protected render() {
-    console.log("render", this, this.context);
     if (this.context?.error) {
       return getErrorElement(this.context.error);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Task } from "@lit/task";
 import { LitElement, type TemplateResult, css, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { TopsortConfigurationError, TopsortRequestError } from "./errors";
-import type { Auction, Banner, BannerState } from "./types";
+import type { Auction, Banner } from "./types";
 
 /* Set up global environment for TS_BANNERS */
 
@@ -76,8 +76,8 @@ export class TopsortBanner extends LitElement {
   readonly location?: string;
 
   private task = new Task(this, {
-    task: this.runAuction,
-    args: () => [this.buildAuction()],
+    task: (...args) => this.runAuction(...args),
+    args: () => [],
   });
 
   private getLink(banner: Banner): string {
@@ -182,10 +182,9 @@ export class TopsortBanner extends LitElement {
     return auction;
   }
 
-  private async runAuction(
-    [auction]: Auction[],
-    { signal }: { signal: AbortSignal },
-  ): Promise<BannerState> {
+  private async runAuction(_: never[], { signal }: { signal: AbortSignal }): Promise<Banner[]> {
+    const auction = this.buildAuction();
+    console.debug("Running auction", auction);
     const device = getDeviceType();
     const token = window.TS.token;
     const url = window.TS.url || "https://api.topsort.com";
@@ -214,15 +213,7 @@ export class TopsortBanner extends LitElement {
       logError(result.error);
       throw new Error(result.error);
     }
-    if (result.winners.length) {
-      return {
-        status: "ready",
-        banners: result.winners,
-      };
-    }
-    return {
-      status: "nowinners",
-    };
+    return result.winners;
   }
 
   protected render() {
@@ -231,12 +222,12 @@ export class TopsortBanner extends LitElement {
     }
     return this.task.render({
       pending: () => this.getLoadingElement(),
-      complete: (value) => {
-        this.emitEvent(value.status);
-        if (value.status === "nowinners") {
+      complete: (banners) => {
+        this.emitEvent(banners.length ? "ready" : "nowinners");
+        if (!banners.length) {
           return this.getNoWinnersElement();
         }
-        return this.getBannerElement(value.banners[0]);
+        return this.getBannerElement(banners[0]);
       },
       error: (error) => this.getErrorElement(error),
     });

--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -18,7 +18,7 @@ export declare class BannerComponentInterface {
   newTab: boolean;
 
   emitEvent(status: string): void;
-  buildAuction(): Auction;
+  buildAuction(slots: number): Auction;
 }
 
 export const BannerComponent = <T extends Constructor<LitElement>>(Base: T) => {
@@ -50,11 +50,11 @@ export const BannerComponent = <T extends Constructor<LitElement>>(Base: T) => {
     @property({ attribute: "new-tab", type: Boolean })
     readonly newTab: boolean = false;
 
-    buildAuction(): Auction {
+    buildAuction(slots: number): Auction {
       const device = getDeviceType();
       const auction: Auction = {
         type: "banners",
-        slots: 1,
+        slots: slots,
         device,
         slotId: this.slotId,
       };

--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -15,6 +15,7 @@ export declare class BannerComponentInterface {
   categoryDisjunctions?: string;
   searchQuery?: string;
   location?: string;
+  newTab: boolean;
 
   emitEvent(status: string): void;
   buildAuction(): Auction;
@@ -45,6 +46,9 @@ export const BannerComponent = <T extends Constructor<LitElement>>(Base: T) => {
 
     @property({ attribute: "location", type: String })
     readonly location?: string;
+
+    @property({ attribute: "new-tab", type: Boolean })
+    readonly newTab: boolean = false;
 
     buildAuction(): Auction {
       const device = getDeviceType();

--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -1,0 +1,90 @@
+import type { LitElement } from "lit";
+import { property } from "lit/decorators.js";
+import { getDeviceType } from "./auction";
+import type { Auction } from "./types";
+
+// biome-ignore lint/suspicious/noExplicitAny: We need to use `any` here
+type Constructor<T> = new (...args: any[]) => T;
+
+export declare class BannerComponentInterface {
+  slotId: string;
+  width: number;
+  height: number;
+  categoryId?: string;
+  categoryIds?: string;
+  categoryDisjunctions?: string;
+  searchQuery?: string;
+  location?: string;
+
+  emitEvent(status: string): void;
+  buildAuction(): Auction;
+}
+
+export const BannerComponent = <T extends Constructor<LitElement>>(Base: T) => {
+  class BannerComponent extends Base {
+    @property({ type: Number })
+    readonly width: number = 0;
+
+    @property({ type: Number })
+    readonly height: number = 0;
+
+    @property({ attribute: "id", type: String })
+    readonly slotId: string = "";
+
+    @property({ attribute: "category-id", type: String })
+    readonly categoryId?: string;
+
+    @property({ attribute: "category-ids", type: String })
+    readonly categoryIds?: string;
+
+    @property({ attribute: "category-disjunctions", type: String })
+    readonly categoryDisjunctions?: string;
+
+    @property({ attribute: "search-query", type: String })
+    readonly searchQuery?: string;
+
+    @property({ attribute: "location", type: String })
+    readonly location?: string;
+
+    buildAuction(): Auction {
+      const device = getDeviceType();
+      const auction: Auction = {
+        type: "banners",
+        slots: 1,
+        device,
+        slotId: this.slotId,
+      };
+      if (this.categoryId) {
+        auction.category = {
+          id: this.categoryId,
+        };
+      } else if (this.categoryIds) {
+        auction.category = {
+          ids: this.categoryIds.split(",").map((item) => item.trim()),
+        };
+      } else if (this.categoryDisjunctions) {
+        auction.category = {
+          disjunctions: [this.categoryDisjunctions.split(",").map((item) => item.trim())],
+        };
+      } else if (this.searchQuery) {
+        auction.searchQuery = this.searchQuery;
+      }
+      if (this.location) {
+        auction.geoTargeting = {
+          location: this.location,
+        };
+      }
+      return auction;
+    }
+
+    emitEvent(status: string) {
+      const event = new CustomEvent("statechange", {
+        detail: { slotId: this.slotId, status },
+        bubbles: true,
+        composed: true,
+      });
+      this.dispatchEvent(event);
+    }
+  }
+  return BannerComponent as Constructor<BannerComponentInterface> & T;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,3 @@
-export interface NoWinners {
-  status: "nowinners";
-}
-
-export interface Ready {
-  status: "ready";
-  banners: Banner[];
-}
-
 export interface Auction {
   type: "banners";
   slots: 1;
@@ -30,5 +21,3 @@ export interface Banner {
   resolvedBidId: string;
   asset: [{ url: string }];
 }
-
-export type BannerState = NoWinners | Ready;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
+import type { Task } from "@lit/task";
+
 export interface Auction {
   type: "banners";
-  slots: 1;
+  slots: number;
   device: "mobile" | "desktop";
   slotId: string;
   category?: {
@@ -20,4 +22,11 @@ export interface Banner {
   id: string;
   resolvedBidId: string;
   asset: [{ url: string }];
+}
+
+export interface BannerContext {
+  width: number;
+  height: number;
+  banners?: Banner[];
+  error?: unknown;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
-import type { Task } from "@lit/task";
-
 export interface Auction {
   type: "banners";
   slots: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface Banner {
 export interface BannerContext {
   width: number;
   height: number;
+  newTab: boolean;
   banners?: Banner[];
   error?: unknown;
-  newTab: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,4 +27,5 @@ export interface BannerContext {
   height: number;
   banners?: Banner[];
   error?: unknown;
+  newTab: boolean;
 }


### PR DESCRIPTION
Introduce 1 new components: `topsort-banner-slot`. This provides a way to show multiple banners for one slotId and running one auction.

Now `topsort-banner` can be used in two ways: Rendering one banner, or multiple.

Example use case of multiple banners:
```html
<topsort-banner context="true" id="an-example-id" width="800" height="400">
  <topsort-banner-slot rank="1"></topsort-banner-slot>
  <topsort-banner-slot rank="2"></topsort-banner-slot>
</topsort-banner>
```

Also update the index.html demo page to showcase all the banner elements.

And refactor the main logic of the main banner as a [mixin](https://lit.dev/docs/composition/mixins/) so it is reusable between the different components.