### PR TITLE
fix: X-UA header device type typo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -199,7 +199,7 @@ export class TopsortBanner extends LitElement {
       headers: {
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
-        "X-UA": `topsort/banners-${import.meta.env.PACKAGE_VERSION} (${device}})`,
+        "X-UA": `topsort/banners-${import.meta.env.PACKAGE_VERSION} (${device})`,
       },
       body: JSON.stringify({
         auctions: [auction],


### PR DESCRIPTION
There is a typo when adding the device type into the X-UA header as the following image shows.

<img width="360" alt="Screenshot 2024-07-05 at 12 45 36" src="https://github.com/Topsort/banners.js/assets/37385297/c3612117-1aa7-45aa-85c0-35c20455436a">

This pull request removes the extra brace.
