### PR TITLE
Add video support to banners.js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,10 +82,27 @@ function getBannerElement(
     const element = window.TS_BANNERS.getBannerElement(banner);
     return html`${element}`;
   }
+
+  if (!banner.asset?.[0]?.url) {
+    logError(new Error("Invalid banner asset: missing URL"));
+    return html``;
+  }
   const src = banner.asset[0].url;
 
-  // classifying if the banner is a video
-  const isVideo = src.endsWith(".mp4") || src.endsWith(".mov") || src.endsWith(".m3u8");
+  const isVideo = (() => {
+    try {
+      const url = new URL(src);
+      const parts = url.pathname.split("/");
+      const manifestIndex = parts.indexOf("manifest");
+      if (manifestIndex >= 0) {
+        const nextSegment = parts[manifestIndex + 1];
+        return nextSegment?.startsWith("video") ?? false;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  })();
   const media = isVideo
     ? html`
         <iframe

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,11 @@ import { consume, createContext, provide } from "@lit/context";
 import { Task } from "@lit/task";
 import { LitElement, type TemplateResult, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import getVideoAssetUrl from "../utils/transform-video-urls";
 import { runAuction } from "./auction";
 import { TopsortConfigurationError } from "./errors";
 import { BannerComponent } from "./mixin";
 import type { Banner, BannerContext } from "./types";
-import getVideoAssetUrl from "../utils/transform-video-urls";
 
 /* Set up global environment for TS_BANNERS */
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { consume, createContext, provide } from "@lit/context";
 import { Task } from "@lit/task";
-import { LitElement, type TemplateResult, css, html } from "lit";
+import { LitElement, type TemplateResult, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { runAuction } from "./auction";
 import { TopsortConfigurationError } from "./errors";
@@ -83,9 +83,9 @@ function getBannerElement(
     return html`${element}`;
   }
   const src = banner.asset[0].url;
-  
+
   // classifying if the banner is a video
-  const isVideo = src.endsWith(".mp4") || src.endsWith(".mov") || src.endsWith(".m3u8")
+  const isVideo = src.endsWith(".mp4") || src.endsWith(".mov") || src.endsWith(".m3u8");
   const media = isVideo
     ? html`
         <iframe
@@ -104,12 +104,12 @@ function getBannerElement(
           style="width:${width}px; height:${height}px; object-fit:cover;"
         />
       `;
-  
+
   const href = getLink(banner);
   const wrappedMedia = newTab
     ? html`<a href="${href}" target="_blank">${media}</a>`
     : html`<a href="${href}">${media}</a>`;
-    return html`
+  return html`
     <div
       data-ts-clickable
       data-ts-resolved-bid=${banner.resolvedBidId}

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,8 +83,7 @@ function getBannerElement(
     return html`${element}`;
   }
   const src = banner.asset[0].url;
-  console.log(src);
-
+  
   // classifying if the banner is a video
   const isVideo = src.endsWith(".mp4") || src.endsWith(".mov") || src.endsWith(".m3u8")
   const media = isVideo
@@ -107,7 +106,6 @@ function getBannerElement(
       `;
   
   const href = getLink(banner);
-  // const imgtag = html`<img src="${src}" alt="Topsort banner"></img>`;
   const wrappedMedia = newTab
     ? html`<a href="${href}" target="_blank">${media}</a>`
     : html`<a href="${href}">${media}</a>`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { runAuction } from "./auction";
 import { TopsortConfigurationError } from "./errors";
 import { BannerComponent } from "./mixin";
 import type { Banner, BannerContext } from "./types";
+import getVideoAssetUrl from "../utils/transform-video-urls";
 
 /* Set up global environment for TS_BANNERS */
 
@@ -82,25 +83,43 @@ function getBannerElement(
     return html`${element}`;
   }
   const src = banner.asset[0].url;
-  const style = css`
-      img {
-        width: ${width}px;
-        height: ${height}px;
-      }
-    `;
+  console.log(src);
+
+  // classifying if the banner is a video
+  const isVideo = src.endsWith(".mp4") || src.endsWith(".mov") || src.endsWith(".m3u8")
+  const media = isVideo
+    ? html`
+        <iframe
+          src="${getVideoAssetUrl(src)}"
+          autoplay
+          muted
+          loop
+          playsinline
+          style="width:${width}px; height:${height}px; object-fit:cover;"
+        ></iframe>
+      `
+    : html`
+        <img
+          src="${src}"
+          alt="Topsort banner"
+          style="width:${width}px; height:${height}px; object-fit:cover;"
+        />
+      `;
+  
   const href = getLink(banner);
-  const imgtag = html`<img src="${src}" alt="Topsort banner"></img>`;
-  const atag = newTab
-    ? html`<a href="${href}" target="_blank">${imgtag}</a>`
-    : html`<a href="${href}">${imgtag}</a>`;
-  return html`
-        <div style="${style}"
-             data-ts-clickable
-             data-ts-resolved-bid=${banner.resolvedBidId}
-             class="ts-banner">
-          ${atag}
-        </div>
-        `;
+  // const imgtag = html`<img src="${src}" alt="Topsort banner"></img>`;
+  const wrappedMedia = newTab
+    ? html`<a href="${href}" target="_blank">${media}</a>`
+    : html`<a href="${href}">${media}</a>`;
+    return html`
+    <div
+      data-ts-clickable
+      data-ts-resolved-bid=${banner.resolvedBidId}
+      class="ts-banner"
+    >
+      ${wrappedMedia}
+    </div>
+  `;
 }
 
 const bannerContext = createContext<BannerContext>(Symbol("banner-context"));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
     "useDefineForClassFields": false,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "utils/transform-video-urls.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/utils/transform-video-urls.ts
+++ b/utils/transform-video-urls.ts
@@ -5,12 +5,13 @@
  * @returns The transformed URL or null if the URL is invalid
  */
 export default function getVideoAssetUrl(url: string | undefined) {
-    try {
-      const urlObj = new URL(url ?? "");
-      const videoUrl = `${urlObj.origin}${urlObj.pathname.split("/manifest")[0]}/iframe${urlObj.search}`;
-      return videoUrl;
-    } catch (error) {
-      return null;
-    }
+  try {
+    const urlObj = new URL(url ?? "");
+    const videoUrl = `${urlObj.origin}${urlObj.pathname.split("/manifest")[0]}/iframe${
+      urlObj.search
+    }`;
+    return videoUrl;
+  } catch (error) {
+    return null;
   }
-  
+}

--- a/utils/transform-video-urls.ts
+++ b/utils/transform-video-urls.ts
@@ -1,0 +1,16 @@
+/**
+ * Transforms manifest URLs to iframe URLs.
+ *
+ * @param url - The URL to transform
+ * @returns The transformed URL or null if the URL is invalid
+ */
+export default function getVideoAssetUrl(url: string | undefined) {
+    try {
+      const urlObj = new URL(url ?? "");
+      const videoUrl = `${urlObj.origin}${urlObj.pathname.split("/manifest")[0]}/iframe${urlObj.search}`;
+      return videoUrl;
+    } catch (error) {
+      return null;
+    }
+  }
+  


### PR DESCRIPTION
**Summary of changes:**
- Created the function "getVideoAssetUrl" to transform video banner URLs to iframe URLs (iframe used as it supports most major browsers https://caniuse.com/?search=iframe)
- Updated the html rendering component in index.ts to allow videos

**Tests conducted:**
- Successfully rendered video banners created through the Topsorted UI
- Successfully rendered both existing and newly created img banners
- Correctly excluded both img and video banners that did not win the auction when attempting to render

This closes ticket, https://topsort.atlassian.net/browse/INTE-1495
