### PR TITLE
fix: use analytics.js IIFE bundle to fix missing telemetry events

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Directly from unpkg.com
   type="module"
   src="https://unpkg.com/@topsort/banners/dist/banners.mjs"
 ></script>
-<script async type="module" src="https://unpkg.com/@topsort/analytics.js"></script>
+<script async src="https://unpkg.com/@topsort/analytics.js/dist/ts.iife.js"></script>
 <body>
   <topsort-banner width="600" height="400" id="<your slot id>"></topsort-banner>
 </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -29,7 +29,7 @@
         },
       };
     </script>
-    <script async type="module" src="https://unpkg.com/@topsort/analytics.js"></script>
+    <script async src="https://unpkg.com/@topsort/analytics.js/dist/ts.iife.js"></script>
     <script src="./dist/banners.iife.js"></script>
     <style>
       *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
       type="module"
       src="node_modules/skeleton-webcomponent-loader/dist/skeleton-webcomponent/skeleton-webcomponent.esm.js"
     ></script>
-    <script async type="module" src="https://unpkg.com/@topsort/analytics.js"></script>
+    <script async src="https://unpkg.com/@topsort/analytics.js/dist/ts.iife.js"></script>
     <script async type="module" src="src/index.ts"></script>
   </head>
   <script>


### PR DESCRIPTION
## Summary

- The bare unpkg URL (`@topsort/analytics.js`) resolves to the UMD build (`dist/ts.js`) which expects `@topsort/sdk` as an external dependency via `window.sdk`. In the browser this is `undefined`, so the event reporting function silently fails — **impressions and clicks never fire**.
- Switch all three references (`README.md`, `index.html`, `demo/index.html`) to the self-contained IIFE build (`dist/ts.iife.js`) which bundles `@topsort/sdk` inline.
- Drop `type="module"` since the IIFE is not an ES module.

## How to verify

1. Open the playground (`demo/index.html`), enter a token and slot ID
2. Render a banner
3. Open DevTools Network tab — filter by `event`
4. Impression events should now fire when the banner enters the viewport
5. Click events should fire on banner click

Previously `window.sdk` was `undefined` (verifiable via console) and no event requests appeared in the Network tab.

## Test plan

- [ ] Playground: banner renders, impression fires on scroll-into-view, click fires on click
- [ ] DevTools console shows no "Missing TS token" or SDK errors
- [ ] `window.sdk` is no longer needed (IIFE bundles it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)