### PR TITLE
security(deps): override transitive postcss to ^8.5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
   ],
   "pnpm": {
     "overrides": {
-      "brace-expansion": ">=2.0.2"
+      "brace-expansion": ">=2.0.2",
+      "postcss": "^8.5.10"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   brace-expansion: '>=2.0.2'
+  postcss: ^8.5.10
 
 importers:
 
@@ -1184,8 +1185,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   punycode@2.3.0:
@@ -2584,7 +2585,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss@8.5.6:
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -2866,7 +2867,7 @@ snapshots:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.6
+      postcss: 8.5.12
       rollup: 4.53.2
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
## Summary

Closes [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) (postcss XSS via unescaped \`</style>\` in CSS Stringify, medium severity).

postcss is a **transitive devDep only** — pulled by \`vite@7.3.2\` and \`vitest\`. Not in the published bundle, so no runtime impact for SDK consumers. Override forces resolution to latest 8.5.x (currently 8.5.12).

## Why an override instead of merging #157

PR #157 (\`update dev tooling (major)\`) bumps Vite 7→8 and several other dev tools, transitively fixing the same alert via Vite 8's newer postcss. This PR is the surgical alternative: 7 lines changed vs ~450 in #157, no Vite major to validate. We can still ship #157 separately as a non-security upgrade.

## Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test:run\` — 102 / 102 passing
- [x] \`pnpm build\` — iife + mjs bundles built
- [x] \`pnpm size\` — 10.59 kB / 11.59 kB (under 13 / 15 kB limits)
- [x] \`pnpm why postcss\` — single version 8.5.12