### PR TITLE
chore(ci): harden release and lint workflows against supply-chain risk

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
       - name: Install Actionlint
         env:
           version: "1.7.7"
-        run: curl -Ls "https://github.com/rhysd/actionlint/releases/download/v${{ env.version }}/actionlint_${{ env.version }}_linux_amd64.tar.gz" | sudo tar -x -z -C /usr/local/bin actionlint
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@v${{ env.version }}
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Run Actionlint
         run: |
           echo "::add-matcher::.github/matchers/actionlint.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,6 @@ jobs:
         with:
           cache: pnpm
           node-version-file: package.json
-          registry-url: https://registry.npmjs.org
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -47,9 +43,17 @@ jobs:
       - name: Build dist
         run: pnpm run build
 
+      - name: Configure npm registry auth
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+          registry-url: https://registry.npmjs.org
+
       - name: Update npm
         run: npm install -g npm@latest
-  
+
       - name: Publish to npm
         id: publish
         run: npm publish --no-git-checks --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary

Defense-in-depth hardening of CI workflows in response to the [April 29, 2026 Socket report on the TeamPCP / SAP CAP npm supply-chain attack](https://socket.dev/blog/sap-cap-npm-packages-supply-chain-attack). A repo-wide audit found no exposure to the compromised packages (\`mbt@1.2.48\`, \`@cap-js/db-service@2.10.1\`, \`@cap-js/postgres@2.2.2\`, \`@cap-js/sqlite@2.2.2\`) or the published IOCs (\`setup.mjs\`, \`execution.js\`, \`OhNoWhatsGoingOnWithGitHub\`, \`A Mini Shai-Hulud has Appeared\`, metadata endpoint probes, \`.claude\`/\`.vscode\` persistence files, suspicious \`preinstall\`, etc.), so this PR is purely workflow hardening — no source or dependency changes.

### \`.github/workflows/release.yml\`
- Removed \`registry-url: https://registry.npmjs.org\` (and a stray \`NODE_AUTH_TOKEN\` \`env:\` block) from the initial \`Set up Node.js\` step. \`pnpm install --frozen-lockfile\`, \`pnpm typecheck\`, \`pnpm test:run\`, and \`pnpm run build\` now run with **no npm publish auth configured in \`.npmrc\`** and **no \`NPM_PUBLISH_TOKEN\` in env**.
- Added a dedicated \`Configure npm registry auth\` step (a second \`actions/setup-node@v6\` invocation with \`registry-url\`) that runs **after** install/test/build, right before \`npm publish\`. The token only enters env on the \`Publish to npm\` step, as before.

Net effect: even if a malicious install-time dependency were ever introduced into \`pnpm-lock.yaml\`, lifecycle scripts during \`pnpm install\` would run without the publish token reachable via \`.npmrc\` or env.

### \`.github/workflows/lint.yml\`
- Replaced \`curl -Ls … | sudo tar -x -z -C /usr/local/bin actionlint\` with \`actions/setup-go@v6\` + \`go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7\`. Removes the unverified pipe-to-sudo install path; Go's module proxy + checksum database verify the pinned version.

Both changes follow the recommendations laid out in the Socket-incident audit report.

## Test plan
- [ ] CI green on this PR (lint workflow exercises the new actionlint install path).
- [ ] On next \`Release\` workflow run after merge, confirm:
  - [ ] \`Set up Node.js\` step has no \`registry-url\`.
  - [ ] \`pnpm install\`, \`pnpm typecheck\`, \`pnpm test:run\`, \`pnpm run build\` all succeed without npm auth.
  - [ ] \`Configure npm registry auth\` step runs before \`Publish to npm\`.
  - [ ] \`npm publish --no-git-checks --provenance\` succeeds with \`NODE_AUTH_TOKEN\` scoped to that step only.

## References
- [Socket: TeamPCP-Linked Supply Chain Attack Hits SAP CAP and Cloud MTA npm Packages](https://socket.dev/blog/sap-cap-npm-packages-supply-chain-attack)

Made with [Cursor](https://cursor.com)