### PR TITLE
feat: render banners at 100% width when dimensions omitted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ Three custom elements are defined in `src/index.ts`:
 
 `src/mixin.ts` exports `BannerComponent`, a Lit mixin that provides shared reactive properties (`width`, `height`, `slotId`, category filters, `newTab`, etc.) and the `buildAuction()` / `emitEvent()` methods. `TopsortBanner` applies this mixin.
 
+`width` and `height` default to `0` when their attributes are omitted. The default renderer treats `0` as a "not set" sentinel and emits `width:100%` / `height:auto` on the `<img>` (and on the `--ts-banner-width` / `--ts-banner-height` host CSS variables), so a `<topsort-banner>` with no dimensions fills its container at the asset's native aspect ratio rather than rendering 0×0. Dimensions are not part of the `/v2/auctions` request payload — the slot is identified by `slotId` alone.
+
 ### Context Provider Pattern
 
 When `context="true"` is set on `<topsort-banner>`, it uses `@lit/context` to provide a `BannerContext` (banners, dimensions, errors) to descendant `<topsort-banner-slot>` elements. The context has a custom change comparator (`bannerContextHasChanged`) that checks width, height, newTab, error presence, and banners array length.

--- a/src/__tests__/topsort-banner.test.ts
+++ b/src/__tests__/topsort-banner.test.ts
@@ -147,6 +147,42 @@ describe("TopsortBanner", () => {
     expect(htmlEl.style.getPropertyValue("--ts-banner-height")).toBe("250px");
   });
 
+  describe("responsive defaults when width/height attributes omitted", () => {
+    it("renders <img> with width:100% and height:auto", async () => {
+      vi.mocked(runAuction).mockResolvedValue([makeBanner()]);
+      const el = mount({ id: "slot-1" });
+      await taskSettled(el);
+      const img = el.querySelector("img");
+      expect(img).not.toBeNull();
+      const style = img?.getAttribute("style") ?? "";
+      expect(style).toContain("width:100%");
+      expect(style).toContain("height:auto");
+      expect(style).not.toContain("0px");
+    });
+
+    it("sets --ts-banner-width:100% and --ts-banner-height:auto host CSS vars", async () => {
+      vi.mocked(runAuction).mockResolvedValue([makeBanner()]);
+      const el = mount({ id: "slot-1" });
+      await taskSettled(el);
+      const htmlEl = el as HTMLElement;
+      expect(htmlEl.style.getPropertyValue("--ts-banner-width")).toBe("100%");
+      expect(htmlEl.style.getPropertyValue("--ts-banner-height")).toBe("auto");
+    });
+
+    it("falls back per-axis: width set, height omitted → height:auto only", async () => {
+      vi.mocked(runAuction).mockResolvedValue([makeBanner()]);
+      const el = mount({ id: "slot-1", width: "300" });
+      await taskSettled(el);
+      const img = el.querySelector("img");
+      const style = img?.getAttribute("style") ?? "";
+      expect(style).toContain("width:300px");
+      expect(style).toContain("height:auto");
+      const htmlEl = el as HTMLElement;
+      expect(htmlEl.style.getPropertyValue("--ts-banner-width")).toBe("300px");
+      expect(htmlEl.style.getPropertyValue("--ts-banner-height")).toBe("auto");
+    });
+  });
+
   it("predefined mode: applies template and emits 'ready'", async () => {
     const winner = makeBanner({ asset: [{ url: "x", content: { label: "Hello" } }] });
     vi.mocked(runAuction).mockResolvedValue([winner]);
@@ -354,6 +390,18 @@ describe("TopsortBanner", () => {
       slot1.addEventListener("statechange", (e) => slot1Events.push(e as CustomEvent));
       await contextSettled(banner, slot1, slot2);
       expect(slot1Events.some((e) => e.detail.status === "error")).toBe(true);
+    });
+
+    it("slots render width:100% / height:auto when parent has no width/height attrs", async () => {
+      vi.mocked(runAuction).mockResolvedValue([makeBanner(), makeBanner({ id: "b2" })]);
+      const { banner, slot1, slot2 } = mountContext({ id: "slot-1" });
+      await contextSettled(banner, slot1, slot2);
+      const style1 = slot1.querySelector("img")?.getAttribute("style") ?? "";
+      const style2 = slot2.querySelector("img")?.getAttribute("style") ?? "";
+      expect(style1).toContain("width:100%");
+      expect(style1).toContain("height:auto");
+      expect(style2).toContain("width:100%");
+      expect(style2).toContain("height:auto");
     });
 
     it("preserves banner content in slots when parent width/height attribute changes after auction", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,11 @@ function getBannerElement(
   }
   const src = banner.asset[0].url;
 
+  // width/height default to 0 when the attribute is omitted; treat 0 as "not set"
+  // and let the banner fluidly fill its container at the asset's native aspect ratio.
+  const widthStyle = width > 0 ? `${width}px` : "100%";
+  const heightStyle = height > 0 ? `${height}px` : "auto";
+
   const isVideo = (() => {
     try {
       const url = new URL(src);
@@ -110,15 +115,15 @@ function getBannerElement(
     ? html`
         <hls-video
           src="${src}"
-          width="${width}px"
-          height="${height}px"
+          width="${widthStyle}"
+          height="${heightStyle}"
         ></hls-video>
       `
     : html`
         <img
           src="${src}"
           alt="Topsort banner"
-          style="width:${width}px; height:${height}px; object-fit:cover;"
+          style="width:${widthStyle}; height:${heightStyle}; object-fit:cover;"
         />
       `;
 
@@ -269,10 +274,12 @@ export class TopsortBanner extends BannerComponent(LitElement) {
       });
     }
 
-    if (changedProperties.has("width"))
-      this.style.setProperty("--ts-banner-width", `${this.width}px`);
-    if (changedProperties.has("height"))
-      this.style.setProperty("--ts-banner-height", `${this.height}px`);
+    if (changedProperties.has("width")) {
+      this.style.setProperty("--ts-banner-width", this.width > 0 ? `${this.width}px` : "100%");
+    }
+    if (changedProperties.has("height")) {
+      this.style.setProperty("--ts-banner-height", this.height > 0 ? `${this.height}px` : "auto");
+    }
 
     if (
       changedProperties.has("width") ||


### PR DESCRIPTION
## Summary

- When `<topsort-banner>` is rendered without `width`/`height` attributes, the component defaulted to `width=0` / `height=0`, producing an `<img>` with `style=\"width:0px; height:0px\"` — invisible to users but still tagged with `data-ts-clickable` / `data-ts-resolved-bid`, so analytics.js would record impressions on a zero-pixel banner.
- Treat `0` as a \"not set\" sentinel and substitute `width:100%` / `height:auto` on the rendered `<img>` / `<hls-video>` and on the `--ts-banner-width` / `--ts-banner-height` host CSS variables. The banner now fills its container at the asset's native aspect ratio when dimensions are omitted.
- The `/v2/auctions` request is unchanged — width/height were never part of the payload.

## Reproducer

```html
<topsort-banner id=\"teste-busca\" search-query=\"pontos\" style=\"margin: 20px 0;\">
</topsort-banner>
```

**Before:** auction succeeds, but the rendered `<img>` is `width:0px; height:0px` (invisible, still billed).
**After:** rendered `<img>` is `width:100%; height:auto` and visually fills its container.

## Behavior change

This is a minor behavior change for integrations that omit `width`/`height` — they will now render a visible banner instead of an invisible one. Customers who set explicit dimensions are unaffected. Per-axis fallback works too: e.g. `width=\"300\"` with no `height` renders `width:300px; height:auto`.

## Test plan

- [x] `pnpm lint` — passes (only the pre-existing `biome.json` warning unrelated to this change)
- [x] `pnpm test:run` — 106/106 passing, including 4 new regression tests
- [ ] Manually verify in the demo app that a `<topsort-banner>` without `width`/`height` renders at the container's width

## New regression tests

In `src/__tests__/topsort-banner.test.ts`:
- standalone banner: `<img>` style is `width:100%; height:auto` when attributes omitted
- standalone banner: host CSS vars are `--ts-banner-width:100%` / `--ts-banner-height:auto`
- per-axis fallback: `width` set + `height` omitted ⇒ `height:auto` only
- context-mode slots inherit responsive defaults when parent has no dimensions

Each of these fails on `main` (asserts `100%`/`auto` where current code produces `0px`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)