### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 0.9.0
+
+- Add built-in translation support via new `language` attribute on `<topsort-banner>` and context-mode propagation to `<topsort-banner-slot>`
+- Translation values are sourced from prefixed keys in the auction response `content` map (e.g. `enUSctaText`, `ptBRdescription`); base fields are used as silent fallbacks when a translation is missing
+- Support both BCP-47 (`en-US`) and POSIX/Java (`en_US`) separators in the `language` attribute
+- Runtime `language` attribute changes re-apply the template without re-running the auction
+- See `docs/translations-guide.md` for the full integration guide
+
 ### 0.8.2
 
 - Emit `statechange` event from `<topsort-banner-slot>` in context mode (previously only non-context banners emitted the event)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@topsort/banners",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "A web component for displaying Topsort banner ads.",
   "type": "module",
   "author": "Topsort",


### PR DESCRIPTION
## Summary

- Bump `package.json` version from 0.8.2 → 0.9.0
- Add `CHANGELOG.md` entry for the built-in translations feature merged in #191

## Test plan

- [ ] CI is green (build, lint, type checks, unit tests)
- [ ] Merge triggers the release workflow to publish `@topsort/banners@0.9.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)