### PR TITLE
chore(ci): remove codecov integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,13 +33,6 @@ jobs:
       - name: Run tests with coverage
         run: pnpm test:coverage
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/lcov.info
-          fail_ci_if_error: true
-
   build:
     name: Build
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![CI](https://github.com/Topsort/banners.js/actions/workflows/test.yml/badge.svg)](https://github.com/Topsort/banners.js/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/Topsort/banners.js/branch/main/graph/badge.svg)](https://codecov.io/gh/Topsort/banners.js)
 [![npm version](https://img.shields.io/npm/v/@topsort/banners)](https://www.npmjs.com/package/@topsort/banners)
 [![npm downloads](https://img.shields.io/npm/dw/@topsort/banners)](https://www.npmjs.com/package/@topsort/banners)
 ![license](https://img.shields.io/github/license/Topsort/banners.js)


### PR DESCRIPTION
We weren't really using this and the recent changes in ownership made us to reassess the usage of Codecov.