### PR TITLE
fix: defer banner impression until genuinely visible (hidden-menu ghost impressions)

### DIFF
--- a/src/__tests__/template.test.ts
+++ b/src/__tests__/template.test.ts
@@ -318,11 +318,14 @@ describe("applyTemplate", () => {
       expect(container.querySelector("span")?.hasAttribute("data-ts-clickable")).toBe(false);
     });
 
-    it("sets data-ts-resolved-bid when banner is not a fallback", () => {
+    it("stages the bid in data-ts-bid (not data-ts-resolved-bid) when not a fallback", () => {
       const container = makeContainer('<a href="#">link</a>');
       const banner = makeBanner({ isFallback: false });
       applyTemplate(container, banner);
-      expect(container.querySelector("a")?.getAttribute("data-ts-resolved-bid")).toBe("bid-123");
+      // applyTemplate stages the bid; the component promotes it to the
+      // analytics-observed data-ts-resolved-bid only once the element is visible.
+      expect(container.querySelector("a")?.getAttribute("data-ts-bid")).toBe("bid-123");
+      expect(container.querySelector("a")?.hasAttribute("data-ts-resolved-bid")).toBe(false);
     });
 
     it("does not throw when container has no children or [data-ts-clickable]", () => {
@@ -330,13 +333,14 @@ describe("applyTemplate", () => {
       const banner = makeBanner();
       expect(() => applyTemplate(container, banner)).not.toThrow();
       expect(container.querySelector("[data-ts-clickable]")).toBeNull();
-      expect(container.hasAttribute("data-ts-resolved-bid")).toBe(false);
+      expect(container.hasAttribute("data-ts-bid")).toBe(false);
     });
 
-    it("does not set data-ts-resolved-bid when banner is a fallback", () => {
+    it("does not stage a bid when banner is a fallback", () => {
       const container = makeContainer('<a href="#">link</a>');
       const banner = makeBanner({ isFallback: true });
       applyTemplate(container, banner);
+      expect(container.querySelector("a")?.hasAttribute("data-ts-bid")).toBe(false);
       expect(container.querySelector("a")?.hasAttribute("data-ts-resolved-bid")).toBe(false);
     });
   });

--- a/src/__tests__/visibility.test.ts
+++ b/src/__tests__/visibility.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isRendered, whenVisible } from "../visibility";
+
+describe("isRendered", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("uses Element.checkVisibility when available", () => {
+    const el = document.createElement("div");
+    const check = vi.fn().mockReturnValue(false);
+    (el as unknown as { checkVisibility: unknown }).checkVisibility = check;
+    expect(isRendered(el)).toBe(false);
+    expect(check).toHaveBeenCalledWith({
+      contentVisibilityAuto: true,
+      opacityProperty: true,
+      visibilityProperty: true,
+    });
+  });
+
+  it("falls back to computed style when checkVisibility is unavailable", () => {
+    // jsdom does not implement checkVisibility, so this exercises the fallback.
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    expect(isRendered(el)).toBe(true);
+
+    const hidden = document.createElement("div");
+    hidden.style.visibility = "hidden";
+    document.body.appendChild(hidden);
+    expect(isRendered(hidden)).toBe(false);
+
+    const transparent = document.createElement("div");
+    transparent.style.opacity = "0";
+    document.body.appendChild(transparent);
+    expect(isRendered(transparent)).toBe(false);
+  });
+
+  it("returns false when an ancestor is opacity:0", () => {
+    const parent = document.createElement("div");
+    parent.style.opacity = "0";
+    const child = document.createElement("div");
+    parent.appendChild(child);
+    document.body.appendChild(parent);
+    expect(isRendered(child)).toBe(false);
+  });
+});
+
+describe("whenVisible", () => {
+  const OriginalIO = globalThis.IntersectionObserver;
+
+  afterEach(() => {
+    globalThis.IntersectionObserver = OriginalIO;
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("promotes immediately when IntersectionObserver is unavailable (legacy engines)", () => {
+    // @ts-expect-error — simulate an engine without IntersectionObserver
+    globalThis.IntersectionObserver = undefined;
+    const el = document.createElement("div");
+    const onVisible = vi.fn();
+    whenVisible(el, onVisible);
+    expect(onVisible).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT promote a visibility:hidden element that is in the viewport", () => {
+    // Fake IntersectionObserver that immediately reports the target as
+    // intersecting — mirrors analytics.js's geometry-only observer.
+    const observed: Element[] = [];
+    class FakeIO {
+      constructor(private cb: IntersectionObserverCallback) {}
+      observe(target: Element) {
+        observed.push(target);
+        // Report intersecting synchronously, like a visible-in-viewport box.
+        this.cb(
+          [{ target, isIntersecting: true } as unknown as IntersectionObserverEntry],
+          this as unknown as IntersectionObserver,
+        );
+      }
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return [];
+      }
+    }
+    // @ts-expect-error — install fake
+    globalThis.IntersectionObserver = FakeIO;
+
+    const el = document.createElement("div");
+    el.style.visibility = "hidden"; // in the viewport geometrically, but hidden
+    document.body.appendChild(el);
+
+    const onVisible = vi.fn();
+    whenVisible(el, onVisible);
+
+    // Geometrically intersecting, but not genuinely rendered → no promotion.
+    expect(onVisible).not.toHaveBeenCalled();
+  });
+
+  it("promotes a genuinely visible element that intersects the viewport", () => {
+    class FakeIO {
+      constructor(private cb: IntersectionObserverCallback) {}
+      observe(target: Element) {
+        this.cb(
+          [{ target, isIntersecting: true } as unknown as IntersectionObserverEntry],
+          this as unknown as IntersectionObserver,
+        );
+      }
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return [];
+      }
+    }
+    // @ts-expect-error — install fake
+    globalThis.IntersectionObserver = FakeIO;
+
+    const el = document.createElement("div");
+    document.body.appendChild(el); // default styles → rendered
+    const onVisible = vi.fn();
+    whenVisible(el, onVisible);
+    expect(onVisible).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/visibility.test.ts
+++ b/src/__tests__/visibility.test.ts
@@ -98,6 +98,63 @@ describe("whenVisible", () => {
     expect(onVisible).not.toHaveBeenCalled();
   });
 
+  it("stops polling once the hidden element is removed from the DOM", () => {
+    vi.useFakeTimers();
+    class FakeIO {
+      constructor(private cb: IntersectionObserverCallback) {}
+      observe(target: Element) {
+        this.cb(
+          [{ target, isIntersecting: true } as unknown as IntersectionObserverEntry],
+          this as unknown as IntersectionObserver,
+        );
+      }
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return [];
+      }
+    }
+    // @ts-expect-error — install fake
+    globalThis.IntersectionObserver = FakeIO;
+
+    const el = document.createElement("div");
+    el.style.visibility = "hidden";
+    document.body.appendChild(el);
+    const onVisible = vi.fn();
+    whenVisible(el, onVisible);
+
+    // Poll is running while hidden + in-viewport.
+    const cleared = vi.spyOn(globalThis, "clearInterval");
+    el.remove(); // detached before it ever became visible
+    vi.advanceTimersByTime(250); // next poll tick observes !isConnected
+    expect(onVisible).not.toHaveBeenCalled();
+    expect(cleared).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("cleanup() stops the watcher and never promotes", () => {
+    class FakeIO {
+      cb: IntersectionObserverCallback;
+      constructor(cb: IntersectionObserverCallback) {
+        this.cb = cb;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return [];
+      }
+    }
+    // @ts-expect-error — install fake
+    globalThis.IntersectionObserver = FakeIO;
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const onVisible = vi.fn();
+    const cleanup = whenVisible(el, onVisible);
+    cleanup();
+    expect(onVisible).not.toHaveBeenCalled();
+  });
+
   it("promotes a genuinely visible element that intersects the viewport", () => {
     class FakeIO {
       constructor(private cb: IntersectionObserverCallback) {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,19 +155,34 @@ const gated = new WeakSet<Element>();
  * Promotes staged `data-ts-bid` → `data-ts-resolved-bid` once each carrier
  * element is genuinely rendered. analytics.js observes `data-ts-resolved-bid`,
  * so this defers the impression trigger until the banner is actually visible.
+ *
+ * Each visibility watcher's cleanup is recorded on `cleanups` so the host
+ * component can tear observers/timers down in `disconnectedCallback` — without
+ * this, a watcher for a never-revealed hidden banner would run indefinitely and
+ * detached elements would leak their observers.
  */
-function promoteWhenVisible(root: Element) {
+function promoteWhenVisible(root: Element, cleanups: Array<{ el: Element; cleanup: () => void }>) {
   const pending = root.querySelectorAll<HTMLElement>("[data-ts-bid]:not([data-ts-resolved-bid])");
   for (const el of pending) {
     if (gated.has(el)) continue;
     const bid = el.getAttribute("data-ts-bid");
     if (!bid) continue;
     gated.add(el);
-    whenVisible(el, () => {
+    const cleanup = whenVisible(el, () => {
       el.setAttribute("data-ts-resolved-bid", bid);
       el.removeAttribute("data-ts-bid");
     });
+    cleanups.push({ el, cleanup });
   }
+}
+
+/** Disconnects visibility watchers and releases their elements for re-gating. */
+function teardownVisibility(cleanups: Array<{ el: Element; cleanup: () => void }>) {
+  for (const { el, cleanup } of cleanups) {
+    cleanup();
+    gated.delete(el);
+  }
+  cleanups.length = 0;
 }
 
 const bannerContext = createContext<BannerContext>(Symbol("banner-context"));
@@ -349,7 +364,14 @@ export class TopsortBanner extends BannerComponent(LitElement) {
     }
 
     // Gate the impression trigger on real visibility (default + predefined mode).
-    promoteWhenVisible(this);
+    promoteWhenVisible(this, this._visibilityCleanups);
+  }
+
+  private readonly _visibilityCleanups: Array<{ el: Element; cleanup: () => void }> = [];
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    teardownVisibility(this._visibilityCleanups);
   }
 
   // avoid shadow dom since we cannot attach to events via analytics.js
@@ -456,7 +478,14 @@ export class TopsortBannerSlot extends LitElement {
     }
 
     // Gate the impression trigger on real visibility (default + predefined mode).
-    promoteWhenVisible(this);
+    promoteWhenVisible(this, this._visibilityCleanups);
+  }
+
+  private readonly _visibilityCleanups: Array<{ el: Element; cleanup: () => void }> = [];
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    teardownVisibility(this._visibilityCleanups);
   }
 
   private _emitStateChange(status: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { TopsortConfigurationError } from "./errors";
 import { BannerComponent } from "./mixin";
 import { applyTemplate } from "./template";
 import type { Banner, BannerContext, HlsConstructor } from "./types";
+import { whenVisible } from "./visibility";
 
 /* Set up global environment for TS_BANNERS */
 
@@ -131,15 +132,42 @@ function getBannerElement(
   const wrappedMedia = newTab
     ? html`<a href="${href}" target="_blank">${media}</a>`
     : html`<a href="${href}">${media}</a>`;
+  // Stage the bid in `data-ts-bid`, not `data-ts-resolved-bid`. The observed
+  // telemetry attribute is promoted only once the element is genuinely visible
+  // (see promoteWhenVisible), so analytics.js cannot fire a phantom impression
+  // for a banner that is in the DOM but hidden (e.g. a preloaded mega-menu).
   return html`
     <div
       data-ts-clickable
-      data-ts-resolved-bid=${ifDefined(banner.isFallback ? undefined : banner.resolvedBidId)}
+      data-ts-bid=${ifDefined(banner.isFallback ? undefined : banner.resolvedBidId)}
       class="ts-banner"
     >
       ${wrappedMedia}
     </div>
   `;
+}
+
+// Tracks elements already handed to the visibility gate so repeated `updated()`
+// calls don't attach duplicate observers.
+const gated = new WeakSet<Element>();
+
+/**
+ * Promotes staged `data-ts-bid` → `data-ts-resolved-bid` once each carrier
+ * element is genuinely rendered. analytics.js observes `data-ts-resolved-bid`,
+ * so this defers the impression trigger until the banner is actually visible.
+ */
+function promoteWhenVisible(root: Element) {
+  const pending = root.querySelectorAll<HTMLElement>("[data-ts-bid]:not([data-ts-resolved-bid])");
+  for (const el of pending) {
+    if (gated.has(el)) continue;
+    const bid = el.getAttribute("data-ts-bid");
+    if (!bid) continue;
+    gated.add(el);
+    whenVisible(el, () => {
+      el.setAttribute("data-ts-resolved-bid", bid);
+      el.removeAttribute("data-ts-bid");
+    });
+  }
 }
 
 const bannerContext = createContext<BannerContext>(Symbol("banner-context"));
@@ -319,6 +347,9 @@ export class TopsortBanner extends BannerComponent(LitElement) {
         logError(e);
       }
     }
+
+    // Gate the impression trigger on real visibility (default + predefined mode).
+    promoteWhenVisible(this);
   }
 
   // avoid shadow dom since we cannot attach to events via analytics.js
@@ -423,6 +454,9 @@ export class TopsortBannerSlot extends LitElement {
         this._emitStateChange("error");
       }
     }
+
+    // Gate the impression trigger on real visibility (default + predefined mode).
+    promoteWhenVisible(this);
   }
 
   private _emitStateChange(status: string) {

--- a/src/template.ts
+++ b/src/template.ts
@@ -99,7 +99,10 @@ export function applyTemplate(container: Element, banner: Banner, language?: str
   if (wrapper) {
     wrapper.setAttribute("data-ts-clickable", "");
     if (!banner.isFallback) {
-      wrapper.setAttribute("data-ts-resolved-bid", banner.resolvedBidId);
+      // Stage the bid; the component promotes it to the analytics-observed
+      // `data-ts-resolved-bid` only once the element is genuinely visible
+      // (see promoteWhenVisible in index.ts / whenVisible in visibility.ts).
+      wrapper.setAttribute("data-ts-bid", banner.resolvedBidId);
     }
   }
 }

--- a/src/visibility.ts
+++ b/src/visibility.ts
@@ -97,6 +97,14 @@ export function whenVisible(el: HTMLElement, onVisible: () => void): () => void 
         // reveal, which won't trigger another IntersectionObserver callback.
         if (timer === undefined) {
           timer = setInterval(() => {
+            // Stop if the element was removed from the DOM before it ever
+            // became visible — otherwise the poll would run forever.
+            if (!el.isConnected) {
+              done = true;
+              stopTimer();
+              io.disconnect();
+              return;
+            }
             if (isRendered(el)) finish();
           }, 200);
         }

--- a/src/visibility.ts
+++ b/src/visibility.ts
@@ -1,0 +1,116 @@
+/**
+ * Real-visibility gate for impression telemetry.
+ *
+ * Background: impressions are fired by `@topsort/analytics.js`, which observes
+ * `data-ts-resolved-bid` with an `IntersectionObserver` (threshold 0.5). That
+ * observer is purely geometric — it treats `visibility:hidden` / `opacity:0`
+ * elements as visible as long as their box overlaps the viewport, and only
+ * respects `display:none`. Merchants that preload markup into a hidden
+ * container (e.g. a mega-menu revealed on hover) therefore get phantom
+ * impressions the moment the auction writes `data-ts-resolved-bid`.
+ *
+ * banners.js closes this gap by withholding `data-ts-resolved-bid` until the
+ * element is *genuinely rendered* — not `display:none`, `visibility:hidden`,
+ * `opacity:0`, or `content-visibility:hidden`. Viewport gating stays with
+ * analytics.js; this module only answers "is it actually painted right now?".
+ */
+
+/**
+ * True when `el` is genuinely rendered — accounts for display, visibility,
+ * opacity and content-visibility on the element and its ancestors.
+ */
+export function isRendered(el: HTMLElement): boolean {
+  const check = (el as unknown as { checkVisibility?: (opts?: unknown) => boolean })
+    .checkVisibility;
+  if (typeof check === "function") {
+    return check.call(el, {
+      contentVisibilityAuto: true,
+      opacityProperty: true,
+      visibilityProperty: true,
+    });
+  }
+  // Fallback for engines without Element.checkVisibility(): walk ancestors.
+  let node: HTMLElement | null = el;
+  while (node) {
+    const style = getComputedStyle(node);
+    // Only an explicit "0" counts as hidden — an unset opacity resolves to ""
+    // in some engines (e.g. jsdom), which must NOT be read as transparent.
+    if (
+      style.display === "none" ||
+      style.visibility === "hidden" ||
+      style.visibility === "collapse" ||
+      style.opacity === "0"
+    ) {
+      return false;
+    }
+    node = node.parentElement;
+  }
+  return true;
+}
+
+/**
+ * Calls `onVisible` once, the first time `el` is both near the viewport and
+ * genuinely rendered. Handles CSS-only reveals (e.g. a menu toggled via
+ * visibility/opacity, which produce no geometry change and thus no
+ * IntersectionObserver callback) by polling `isRendered` while the element is
+ * near the viewport. Polling is bounded — it never runs while the element is
+ * far off-screen. Returns a cleanup function.
+ */
+export function whenVisible(el: HTMLElement, onVisible: () => void): () => void {
+  // No IntersectionObserver (old engines / SSR) → preserve eager behavior.
+  if (typeof IntersectionObserver === "undefined") {
+    onVisible();
+    return () => {};
+  }
+
+  let done = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  const stopTimer = () => {
+    if (timer !== undefined) {
+      clearInterval(timer);
+      timer = undefined;
+    }
+  };
+
+  const finish = () => {
+    if (done) return;
+    done = true;
+    stopTimer();
+    io.disconnect();
+    onVisible();
+  };
+
+  const io = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) {
+          // Far off-screen: don't waste cycles polling for a CSS reveal.
+          stopTimer();
+          continue;
+        }
+        if (isRendered(el)) {
+          finish();
+          return;
+        }
+        // On-screen geometrically but CSS-hidden (closed menu): watch for the
+        // reveal, which won't trigger another IntersectionObserver callback.
+        if (timer === undefined) {
+          timer = setInterval(() => {
+            if (isRendered(el)) finish();
+          }, 200);
+        }
+      }
+    },
+    // Start watching a little before it scrolls in; analytics.js still applies
+    // the precise 0.5 viewport threshold before it fires the impression.
+    { threshold: 0, rootMargin: "200px 0px" },
+  );
+  io.observe(el);
+
+  return () => {
+    done = true;
+    stopTimer();
+    io.disconnect();
+  };
+}


### PR DESCRIPTION
## Problem

Merchants that **preload banner markup into a hidden container** — e.g. a mega-menu whose banner is in the DOM at page load but revealed on hover — get **ghost impressions**: an impression is counted even though the shopper never saw the banner.

## Root cause

banners.js has no impression logic; impressions are fired by `@topsort/analytics.js`, which observes `data-ts-resolved-bid` with an `IntersectionObserver` (threshold `0.5`). That observer is **purely geometric** — it treats `visibility:hidden` / `opacity:0` elements as visible as long as their box overlaps the viewport, and only respects `display:none`. Because banners.js writes `data-ts-resolved-bid` as soon as the auction resolves (regardless of visibility), any banner hidden by something other than `display:none` records an impression on page load.

## Fix

Withhold the analytics-observed attribute until the element is **genuinely rendered**:

- `src/visibility.ts` (new): `isRendered()` uses `Element.checkVisibility({ opacityProperty, visibilityProperty, contentVisibilityAuto })` (with a computed-style ancestor-walk fallback), and `whenVisible()` fires once the element is near the viewport **and** actually painted — polling for CSS-only reveals (a menu toggled via `visibility`/`opacity` produces no `IntersectionObserver` callback).
- `src/index.ts` / `src/template.ts`: the winning bid is staged in a private `data-ts-bid` attribute; `promoteWhenVisible()` (called from both components' `updated()`) promotes it to `data-ts-resolved-bid` only once visible. `data-ts-clickable` and the fallback-bid rules are unchanged.

analytics.js is untouched — it simply never sees a resolved bid on a hidden banner, so its observer can't fire.

## Backward compatibility

No behavior change for normal banners. Visible banners promote on the first `IntersectionObserver` callback (~1 frame). Below-the-fold / carousel banners were already viewport-gated by analytics.js, so the outcome is identical — only *when* `data-ts-resolved-bid` appears moves from "instantly" to "near/in view", which is exactly when an impression should count. Engines without `IntersectionObserver` fall back to the previous eager behavior.

## Testing

- `src/__tests__/visibility.test.ts` (new) + updated `template.test.ts`; full suite green (142 tests), typecheck + lint clean, build under size-limit.
- Verified end-to-end against the **live API** with the real analytics.js: a banner hidden via `visibility:hidden` fires **no** impression; a visible control banner still fires normally; opening the menu promotes the bid and fires a legitimate impression.

## Customer-side note

Affected merchants can also remediate today by hiding the closed menu with `display:none` (instead of `visibility`/`opacity`), which the `IntersectionObserver` respects. This SDK fix covers it centrally regardless of the hide technique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
