### PR TITLE
chore(release): 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.9.1
+
+- Fix ghost impressions for banners preloaded into hidden containers (e.g. mega-menus revealed on hover): `data-ts-resolved-bid` is now withheld until the banner is genuinely rendered — not `display:none`, `visibility:hidden`, `opacity:0`, or `content-visibility:hidden` — so `analytics.js` no longer counts an impression for a banner the shopper never saw. The staged bid lives in `data-ts-bid` until it is promoted on visibility.
+- Tear down visibility watchers when a banner disconnects, and stop polling once a hidden banner is removed from the DOM, preventing timer/observer leaks.
+- Render banners at 100% width (asset's native aspect ratio) when the `width`/`height` attributes are omitted.
+
 ### 0.9.0
 
 - Add built-in translation support via new `language` attribute on `<topsort-banner>` and context-mode propagation to `<topsort-banner-slot>`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@topsort/banners",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A web component for displaying Topsort banner ads.",
   "type": "module",
   "author": "Topsort",


### PR DESCRIPTION
Release **0.9.1**.

Bumps `package.json` and adds the `CHANGELOG.md` entry. Merging then creating the GitHub Release `v0.9.1` triggers `release.yml` → publish to npm.

### Included since 0.9.0
- **Fix ghost impressions** for banners preloaded into hidden containers (e.g. mega-menus revealed on hover) — `data-ts-resolved-bid` is withheld until the banner is genuinely rendered (#197).
- **Prevent timer/observer leaks** — visibility watchers are torn down on disconnect and the poll stops once a hidden banner leaves the DOM (#197).
- **100% width** rendering at native aspect ratio when `width`/`height` are omitted (#189).

No source changes in this PR — version + changelog only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
