### PR TITLE
chore(deps): add @typescript/typescript6 fallback for TS7 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@playwright/test": "^1.58.2",
     "@size-limit/file": "^12.0.0",
     "@types/node": "24.13.0",
+    "@typescript/typescript6": "^6.0.2",
     "@vitest/coverage-v8": "^4.0.18",
     "jsdom": "^29.0.0",
     "size-limit": "^12.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       '@types/node':
         specifier: 24.13.0
         version: 24.13.0
+      '@typescript/typescript6':
+        specifier: ^6.0.2
+        version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.1.5(vitest@4.1.5)
@@ -870,6 +873,10 @@ packages:
 
   '@types/trusted-types@2.0.3':
     resolution: {integrity: sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==}
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
 
   '@vitest/coverage-v8@4.1.5':
     resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
@@ -2384,6 +2391,10 @@ snapshots:
       undici-types: 7.18.2
 
   '@types/trusted-types@2.0.3': {}
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `@typescript/typescript6` as a devDependency to unblock the Renovate TypeScript v7 upgrade (#199).

TypeScript 7 is the native (Go-based) compiler and no longer ships the JavaScript Compiler API. `vite-plugin-dts` 5.x (via `unplugin-dts`) requires that API for declaration generation, so `vite build` fails as soon as TS 7 is installed — this is exactly the failing **Build** check on #199. The plugin has built-in support for falling back to the `@typescript/typescript6` shim, which keeps the 6.x JS API available for tooling while `tsc` runs the fast native binary.

Renovate does not accept manual commits on its branches (they are lost on rebase), so the fallback lands here on `main` first. Once merged, rebasing #199 makes it fully green.

## Behavior on main today

While `typescript` 6.x is installed the fallback package is inert — the plugin keeps using the regular `typescript` JS API. Verified locally on this branch (TS 6.0.3): build, `tsc --noEmit`, all 144 unit tests, Biome lint, and `pnpm install --frozen-lockfile` all pass, and `dist/` output is unchanged.

Also verified with TS 7.0.2 (the #199 scenario): build succeeds via the fallback and the `dist/` artifacts (bundles, sourcemaps, and declaration files) are byte-identical to the TS6 build.

## Notes

- Dev-only dependency; zero runtime/bundle impact (bundle sizes unchanged: 12.38 kB gzip IIFE / 13.95 kB gzip ESM).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6b73032-8c26-4238-bd87-707992da3583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6b73032-8c26-4238-bd87-707992da3583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

