### PR TITLE
fix(e2e): stop flaky banner dimension asserts on broken images

### DIFF
--- a/e2e/helpers/mock.ts
+++ b/e2e/helpers/mock.ts
@@ -1,8 +1,25 @@
 import type { Page } from "@playwright/test";
 
+/** 1×1 PNG so banner <img> requests never hit the network or render as broken images. */
+const PIXEL_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  "base64",
+);
+
 export async function blockCDN(page: Page) {
   await page.route("**analytics**", (route) => route.abort());
   await page.route("**hls.js**", (route) => route.abort());
+  // Auction mocks use example.com asset URLs. Those URLs 404 with HTML, which
+  // makes Chromium treat the <img> as broken and report unstable computed sizes
+  // (e.g. height 18px) even when width/height styles are set. Serve a real PNG.
+  await page.route("**/example.com/**", async (route) => {
+    const url = route.request().url();
+    if (/\.(avif|gif|jpe?g|png|svg|webp)(\?|$)/i.test(url)) {
+      await route.fulfill({ status: 200, contentType: "image/png", body: PIXEL_PNG });
+      return;
+    }
+    await route.continue();
+  });
 }
 
 export async function mockAuctionSuccess(

--- a/e2e/specs/render.spec.ts
+++ b/e2e/specs/render.spec.ts
@@ -35,6 +35,10 @@ test.describe("render", () => {
   test("img is rendered at the dimensions specified on the banner element", async ({ page }) => {
     const img = page.locator(".ts-banner img");
     await expect(img).toBeVisible();
+    // Prefer the inline style the component writes; computed CSS alone has been
+    // flaky in CI when the asset URL 404s as HTML (broken-image intrinsic size).
+    await expect(img).toHaveAttribute("style", /width:\s*600px/);
+    await expect(img).toHaveAttribute("style", /height:\s*400px/);
     await expect(img).toHaveCSS("width", "600px");
     await expect(img).toHaveCSS("height", "400px");
   });


### PR DESCRIPTION
## Summary
- E2E `render › img is rendered at the dimensions specified on the banner element` has been failing intermittently on `main` (including after #199), with computed `height: 18px` (or odd widths like `112px`).
- Root cause: auction mocks point at `https://example.com/banner.jpg`, which 404s as HTML. Chromium then treats the `<img>` as broken and reports unstable computed sizes. Not caused by TS7.
- Fix: fulfill `example.com` image requests with a 1×1 PNG in `blockCDN`, and also assert the inline `style` the component writes.

## Test plan
- [x] `pnpm e2e` (12/12)
- [x] Repeat `render.spec.ts` several times locally

